### PR TITLE
chore(composer): update beberlei/assert to v 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "nyholm/psr7-server": "^1.0",
         "nyholm/psr7": "^1.2",
         "swlib/swpdo": "dev-master",
-        "beberlei/assert": "^3.2",
+        "beberlei/assert": "^3.3",
         "ilexn/swoole-convert-psr7": "^0.3.0",
         "spatie/array-to-xml": "^3.1"
     },


### PR DESCRIPTION
to fix deprecation error for php 8.4

The issue happens when installing the fwlukiman with composer install command