### PR TITLE
fix: correct join ON clause when using array condition

### DIFF
--- a/Cores/Database/Query/Select.php
+++ b/Cores/Database/Query/Select.php
@@ -54,7 +54,7 @@ class Select extends Database_Query {
 		if (is_array($on)) $_on = implode (' AND ', $on);
 		if ($type == 'left') $__join = ' LEFT ' . $__join;
 		else if ($type == 'right') $__join = ' RIGHT ' . $__join;
-		$this->_join[] = $__join . $join . ' ON ( ' . $on . ' ) ';
+		$this->_join[] = $__join . $join . ' ON ( ' . $_on . ' ) ';
 		return $this;
 	}
 


### PR DESCRIPTION
fix: use imploded ON condition in join query builder

Previously, array-based ON conditions were not applied correctly,
causing "Array" to appear in the SQL query. Now using the processed $_on variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect handling of array-based join conditions in database queries. Array conditions are now properly normalized before being embedded into the SQL clause, ensuring accurate query generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->