### PR TITLE
fix: (mail) allow configurable Postal URL scheme

### DIFF
--- a/Cores/Mail/Engine/Postal.php
+++ b/Cores/Mail/Engine/Postal.php
@@ -5,7 +5,9 @@ class Postal extends Base {
 	public function simpleSend(String $to, String $from, String $subject, String $message) : bool {
 
 		//post data to postal server
-		$url = "https://{$this->config['host']}/api/v1/send/message";
+		$scheme = $this->config['scheme'] ?? 'https';
+		$port = !empty($this->config['port']) ? ':' . intval($this->config['port']) : '';
+		$url = "{$scheme}://{$this->config['host']}{$port}/api/v1/send/message";
 		$data = array(
 			"from" => $from,
 			"to" => $to,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mail endpoint URL is now dynamically configurable using scheme and port settings instead of relying on hardcoded values, providing greater flexibility for different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->